### PR TITLE
Signal monitor Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ cython_debug/
 .DS_Store
 env_file
 _log/
+.idea/

--- a/atd-signal-comms/config.py
+++ b/atd-signal-comms/config.py
@@ -43,10 +43,22 @@ CONFIG = [
             "ip_address": "field_3525",
             "device_id": "field_1789",
             # cabinets are not connected to a "locations" object record
-            # there is no ATD_LOCATION_ID field. that's why its not here
+            # there is no ATD_LOCATION_ID field. That's why it's not here
             "location_name": "field_4128",
             "knack_id": "id",
             "signal_id": "field_1798",
+        },
+    },
+    {
+        "device_type": "signal_monitor",
+        "container": "view_1567",
+        "fields": {
+            "ip_address": "field_3616",
+            "device_id": "field_1789",
+            # cabinets are not connected to a "locations" object record
+            # there is no ATD_LOCATION_ID field. That's why it's not here
+            "location_name": "field_4128",
+            "knack_id": "id",
         },
     },
 ]


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/9471

Knack configuration for signal monitors. The IP is under the `Monitor IP` field in the cabinets object in knack.

Ran it this AM with these results for signal monitors:
status | count devices
-- | --
invalid_hostname | 47
online | 671
timeout | 97

Unsure exactly how to test this but I've created a prefect flow where you can run the latest version of this branch in docker.

[deployment](https://app.prefect.cloud/account/62be21ad-87d4-4858-bc47-a49e1fd29df7/workspace/4e909dab-3495-4e26-9403-9b633af2c970/deployments/deployment/16536f09-55b2-4c6d-bd3f-4abc441412f7)

testing:
1. go to the deployment and click run
2. verify that signal monitor and DMS data is being populated in the S3 bucket under today's date in [atd-signal-comms/dev](https://s3.console.aws.amazon.com/s3/buckets/atd-signal-comms?prefix=dev/)

[flow code](https://github.com/cityofaustin/atd-prefect/blob/ch-signal-comms/flows/atd-signal-comms/atd-signal-comms.py
)

Will need to update the airflow deployment of this code to add in the signal monitor 